### PR TITLE
Adjust amino acid and position based on Unimod.

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/utilities/pridemod/model/Specificity.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/pridemod/model/Specificity.java
@@ -82,14 +82,14 @@ public class Specificity implements Comparable {
     }
 
     public enum Position {
-        CTERM, NTERM, PCTERM, PNTERM, NONE
+        CTERM, NTERM, PCTERM, PNTERM, ANYWHERE, NONE
     }
 
     /**
      * To use the same notation of PSI-MOD we decide to include the X as aminoacid. PSI-Mod use X for N-Term position.
      */
     public enum AminoAcid {
-        A, R, N, D, C, E, Q, G, H, K, I, L, M, F, P, S, T, W, Y, V, X, NONE
+        A, R, N, D, C, E, Q, G, H, K, I, L, M, F, P, S, T, W, Y, V, X, NTERM, CTERM, NONE
 
     }
 
@@ -122,6 +122,8 @@ public class Specificity implements Comparable {
         if (s.compareToIgnoreCase("Y") == 0) return AminoAcid.Y;
         if (s.compareToIgnoreCase("V") == 0) return AminoAcid.V;
         if (s.compareToIgnoreCase("X") == 0) return AminoAcid.X;
+        if (s.compareToIgnoreCase("C-term") == 0) return AminoAcid.CTERM;
+        if (s.compareToIgnoreCase("N-term") == 0) return AminoAcid.NTERM;
         return AminoAcid.NONE;
     }
 
@@ -133,10 +135,11 @@ public class Specificity implements Comparable {
      */
     public static Position parsePositon(String s) {
         if (s != null) {
-            if (s.compareToIgnoreCase("N-Term") == 0) return Position.NTERM;
-            if (s.compareToIgnoreCase("C-Term") == 0) return Position.CTERM;
+            if (s.compareToIgnoreCase("Any N-Term") == 0) return Position.NTERM;
+            if (s.compareToIgnoreCase("Any C-Term") == 0) return Position.CTERM;
             if (s.compareToIgnoreCase("Protein N-term") == 0) return Position.PNTERM;
             if (s.compareToIgnoreCase("Protein C-Term") == 0) return Position.PCTERM;
+            if (s.compareToIgnoreCase("Anywhere") == 0) return Position.ANYWHERE;
         }
         return Position.NONE;
     }


### PR DESCRIPTION
There are N-term and C-term besides amino acids. I add these two to the AminoAcid enumerate so that they won't be "NONE".

There are five kinds of positions based on Unimod help and the xml:

>Position: Chosen from a controlled list of categories. Choose "Anywhere" if the modification applies to a residue independent of its position, (e.g. oxidation of methionine). Choose "Any N-term" or "Any C-term" if the modification applies to a residue only when it is at a peptide terminus, (e.g. conversion of methionine to homoserine). Choose "Protein N-term" or "Protein C-term" if the modification only applies to the original terminus of the intact protein, not new peptide termini created by digestion, (e.g. post-translational acetylation of the protein amino terminus). If Site was specified as "N-term" or "C-Term", then "Anywhere" becomes equivalent to "Any N-term" or "Any C-term". Required

Thus, I modified the Position enumerate.
